### PR TITLE
Added support for looping multiple sub-header titles.

### DIFF
--- a/public/portfolio_shared_data.json
+++ b/public/portfolio_shared_data.json
@@ -1,7 +1,7 @@
 {
     "basic_info": {
       "name": "Davina Griss",
-      "title": "Front-end Developer",
+      "titles": [ "Front-end Developer", "Senior Data Engineer", "Dev Team lead", "Mobile App Developer" ],
       "social": [
         {
           "name": "github",

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Projects from "./components/Projects";
 import Skills from "./components/Skills";
 
 class App extends Component {
+
   constructor(props) {
     super();
     this.state = {

--- a/src/App.js
+++ b/src/App.js
@@ -70,7 +70,7 @@ class App extends Component {
       cache: false,
       success: function (data) {
         this.setState({ sharedData: data });
-        document.title = `${this.state.sharedData.basic_info.name} | ${this.state.sharedData.basic_info.title}`;
+        document.title = `${this.state.sharedData.basic_info.name}`;
       }.bind(this),
       error: function (xhr, status, err) {
         alert(err);

--- a/src/App.scss
+++ b/src/App.scss
@@ -15,6 +15,10 @@ html {
 	justify-content: center;
 }
 
+.title-container {
+	height: 50px;
+}
+
 .title-styles {
 	font-family: 'Raleway', sans-serif;
 	font-size: 250%;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,6 +3,8 @@ import Typical from "react-typical";
 import Switch from "react-switch";
 
 class Header extends Component {
+  titles = [];
+
   constructor() {
     super();
     this.state = { checked: false };
@@ -23,11 +25,15 @@ class Header extends Component {
   }
 
   render() {
-    var titles = [];
     if (this.props.sharedData) {
       var name = this.props.sharedData.name;
-      titles = this.props.sharedData.titles.map(x => [ x.toUpperCase(), 1500 ] ).flat();
+      this.titles = this.props.sharedData.titles.map(x => [ x.toUpperCase(), 1500 ] ).flat();
     }
+
+    const HeaderTitleTypeAnimation = React.memo( () => {
+      return <Typical className="title-styles" steps={this.titles} loop={Infinity} />
+    }, (props, prevProp) => true);
+
     return (
       <header id="home" style={{ height: window.innerHeight - 140, display: 'block' }}>
         <div className="row aligner" style={{height: '100%'}}>
@@ -39,7 +45,7 @@ class Header extends Component {
                 <Typical steps={[name]} wrapper="p" />
               </h1>
               <div className="title-container">
-                <Typical className="title-styles" steps={titles} wrapper="p" loop={Infinity} />
+                <HeaderTitleTypeAnimation />
               </div>
               <Switch
                 checked={this.state.checked}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -23,9 +23,10 @@ class Header extends Component {
   }
 
   render() {
+    var titles = [];
     if (this.props.sharedData) {
       var name = this.props.sharedData.name;
-      var title = this.props.sharedData.title.toUpperCase();
+      titles = this.props.sharedData.titles.map(x => [ x.toUpperCase(), 1500 ] ).flat();
     }
     return (
       <header id="home" style={{ height: window.innerHeight - 140, display: 'block' }}>
@@ -37,7 +38,9 @@ class Header extends Component {
               <h1 className="mb-0">
                 <Typical steps={[name]} wrapper="p" />
               </h1>
-              <Typical className="title-styles" steps={[title]} wrapper="p" />
+              <div className="title-container">
+                <Typical className="title-styles" steps={titles} wrapper="p" loop={Infinity} />
+              </div>
               <Switch
                 checked={this.state.checked}
                 onChange={this.onThemeSwitchChange}


### PR DESCRIPTION
Added support for looping multiple titles in Typical component. As a consequence:

- Wrapped the Typical component into a fixed height div due to the bad transitions for a brief moment between two titles when the string is empty (the content bellow jumps up-down very quickly).
- Removed the title from the page document.title due to the increased title length.
