### PR TITLE
Resolve errors logo192 and logo 512

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,6 @@
       name="Portfolio template made by Dorota1997, available at GitHub"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
     <link rel="stylesheet" href="//cdn.rawgit.com/konpa/devicon/df6431e323547add1b4cf45992913f15286456d3/devicon.min.css">

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,16 +6,6 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
     }
   ],
   "start_url": ".",


### PR DESCRIPTION
There is following error message when loading the page: 

![Peek 2021-05-26 15-56](https://user-images.githubusercontent.com/11299099/119672552-fd2e9080-be3a-11eb-823c-6f7dfc94446d.gif)

This is because the logos don't exist (anymore). They are created with create-react-app. Still they are referenced. 
This PR removes the references.

And: Thank you for sharing this awesome template! =)