### PR TITLE
Sass compilation error fix in latest node

### DIFF
--- a/src/scss/themes/theme-dark.scss
+++ b/src/scss/themes/theme-dark.scss
@@ -1,6 +1,6 @@
 body[data-theme="dark"] {  
 
-   @import '../src/scss/dark-slider.scss';
+   @import 'src/scss/dark-slider.scss';
 
    .slider-tab {
       background-color: #8C8C8C;

--- a/src/scss/themes/theme-light.scss
+++ b/src/scss/themes/theme-light.scss
@@ -1,5 +1,5 @@
 body[data-theme="light"] {
-    @import '../src/scss/light-slider.scss';
+    @import 'src/scss/light-slider.scss';
  
     .slider-tab {
        background-color: #D7CAAA;


### PR DESCRIPTION
In the latest node version the import path in the theme sass are making errors. 

The relative path with dots are replaced with absolute path solved the error.